### PR TITLE
Implement PowerTwoRadix using no floating-point arithmetic

### DIFF
--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -24,7 +24,6 @@ pub trait RadixOps<RadixSize> {
 }
 
 /// A numeral string that supports radixes in [2..2^16).
-/// It uses floating-point arithmetic where necessary.
 pub struct FlexibleNumeralString(Vec<u16>);
 
 impl From<Vec<u16>> for FlexibleNumeralString {
@@ -171,7 +170,7 @@ where
         let b = self.radix.calculate_b(v);
 
         // 4. Let d = 4 * ceil(b / 4) + 4.
-        let d = (4f64 * (b as f64 / 4f64).ceil() + 4f64) as usize;
+        let d = 4 * ((b + 3) / 4) + 4;
 
         // 5. Let P = [1, 2, 1] || [radix] || [10] || [u mod 256] || [n] || [t].
         let mut p = vec![1, 2, 1];
@@ -241,7 +240,7 @@ where
         let b = self.radix.calculate_b(v);
 
         // 4. Let d = 4 * ceil(b / 4) + 4.
-        let d = (4f64 * (b as f64 / 4f64).ceil() + 4f64) as usize;
+        let d = 4 * ((b + 3) / 4) + 4;
 
         // 5. Let P = [1, 2, 1] || [radix] || [10] || [u mod 256] || [n] || [t].
         let mut p = vec![1, 2, 1];

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -13,7 +13,7 @@ pub trait NumeralString: Sized {
     fn concat(a: Self, b: Self) -> Self;
 
     fn num_radix(&self, radix: &BigUint) -> BigUint;
-    fn str_radix(x: BigUint, radix: &Self::RadixSize, m: usize) -> Self;
+    fn str_radix(x: BigUint, radix: &BigUint, m: usize) -> Self;
 }
 
 pub trait RadixOps<RadixSize> {
@@ -66,7 +66,7 @@ impl NumeralString for FlexibleNumeralString {
         res
     }
 
-    fn str_radix(mut x: BigUint, radix: &Self::RadixSize, m: usize) -> Self {
+    fn str_radix(mut x: BigUint, radix: &BigUint, m: usize) -> Self {
         let mut res = vec![0; m];
         for i in 0..m {
             res[m - 1 - i] = (&x % radix).to_u16().unwrap();
@@ -213,7 +213,7 @@ where
             let c = (x_a.num_radix(&self.radix_bi) + y) % pow(&self.radix_bi, m);
 
             // 6vii. Let C = STR(c, radix).
-            let x_c = NS::str_radix(c, &self.radix, m);
+            let x_c = NS::str_radix(c, &self.radix_bi, m);
 
             // 6viii. Let A = B.
             x_a = x_b;
@@ -291,7 +291,7 @@ where
             let c = c.to_biguint().unwrap();
 
             // 6vii. Let C = STR(c, radix).
-            let x_c = NS::str_radix(c, &self.radix, m);
+            let x_c = NS::str_radix(c, &self.radix_bi, m);
 
             // 6viii. Let B = A.
             x_b = x_a;


### PR DESCRIPTION
Also includes trait refactors to check that `NumeralString` is valid for the given `Radix`.

Closes #2.