### PR TITLE
Fix subtraction overflow on empty input

### DIFF
--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -25,13 +25,20 @@ impl Numeral for BigUint {
     }
 
     fn to_bytes(&self, b: usize) -> Vec<u8> {
-        let mut ret = Vec::with_capacity(b);
-        let bytes = self.to_bytes_be();
-        for _ in 0..(b - bytes.len()) {
-            ret.push(0);
+        if self.is_zero() {
+            // Because self.to_bytes_be() returns vec![0u8] for zero, instead of vec![], we would
+            // end up with a subtraction overflow on empty input (since (b - bytes.len()) < 0 or
+            // (0 - 1) < 0). This optimization side-steps that special case.
+            vec![0; b]
+        } else {
+            let mut ret = Vec::with_capacity(b);
+            let bytes = self.to_bytes_be();
+            for _ in 0..(b - bytes.len()) {
+                ret.push(0);
+            }
+            ret.extend(bytes);
+            ret
         }
-        ret.extend(bytes);
-        ret
     }
 
     fn add_mod_exp(self, other: Self, radix: u32, m: usize) -> Self {


### PR DESCRIPTION
Because `BigUint::to_bytes_be` would return `vec![0u8]` instead of `vec![]`, an empty input would cause `panicked at 'attempt to subtract with overflow'`. This pull request optimizes for integers which are zero, and therefore side-steps this edge case.

I forgot to report this a while ago because I had been working around this in my reference implementation tests: https://github.com/saleemrashid/binary-ff1/blob/9d18b1fe21597fad3f17ee9dfd015422085d7182/tests/reference_impl.rs#L32-L36