### PR TITLE
Update aes dependency and others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.41.0
+          toolchain: 1.49.0
           override: true
 
       # Ensure all code has been formatted with rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://github.com/str4d/fpe"
 repository = "https://github.com/str4d/fpe"
 
 [dependencies]
-aes = "0.6"
-block-modes = "0.7"
-num-bigint = "0.3"
+aes = "0.7"
+block-modes = "0.8"
+num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ algorithms.
 The following algorithms are implemented:
 - FF1 (specified in [NIST Special Publication 800-38G](http://dx.doi.org/10.6028/NIST.SP.800-38G)).
 
-This crate requires Rust version 1.41 or greater.
+This crate requires Rust version 1.49 or greater.
 
 ## License
 


### PR DESCRIPTION
The newest `aes` version includes improvements to AES-NI instruction support detection, which may speed up cryptographic operations on CPUs that support the extensions without requiring special compile options. As this version MSRV is 1.49, this bumps `fpe` MSRV to 1.49 too.