### PR TITLE
Remove direct dependency on aes crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ homepage = "https://github.com/str4d/fpe"
 repository = "https://github.com/str4d/fpe"
 
 [dependencies]
-aes = "0.7"
 block-modes = "0.8"
+cipher = "0.3"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"
 
 [dev-dependencies]
+aes = "0.7"
 #aes-old = { package = "aes", version = "0.3" }
 #binary-ff1 = "0.1"
 criterion = "0.3"

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -1,11 +1,10 @@
 //! A Rust implementation of the FF1 algorithm, specified in
 //! [NIST Special Publication 800-38G](http://dx.doi.org/10.6028/NIST.SP.800-38G).
 
-use aes::{
-    cipher::{generic_array::GenericArray, Block},
-    BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
-};
 use block_modes::{block_padding::NoPadding, BlockMode, Cbc};
+use cipher::{
+    generic_array::GenericArray, Block, BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
+};
 use std::cmp;
 
 mod alloc;


### PR DESCRIPTION
In practice everyone will use FF1 with AES, as that is the only block
cipher that fits the necessary NIST requirements. But this crate does
not need to depend specifically on the aes crate for anything other
than tests. This commit enables downstream users to use a different
AES implementation if desired (e.g. in an embedded environment with
an existing AES implementation).