### PR TITLE
Support for parameterized number of feistel rounds

### DIFF
--- a/benches/ff1.rs
+++ b/benches/ff1.rs
@@ -5,7 +5,7 @@ use criterion_cycles_per_byte::CyclesPerByte;
 fn ff1_binary_benchmark(c: &mut Criterion<CyclesPerByte>) {
     let bytes = vec![7; 1000];
 
-    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32], 2).unwrap();
+    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32]).unwrap();
     let mut fpe_group = c.benchmark_group("fpe");
     for size in [10, 100, 1000].iter() {
         fpe_group.throughput(Throughput::Bytes(*size as u64));
@@ -13,7 +13,7 @@ fn ff1_binary_benchmark(c: &mut Criterion<CyclesPerByte>) {
             b.iter(|| {
                 fpe_ff.encrypt(
                     &[],
-                    &fpe::ff1::BinaryNumeralString::from_bytes_le(&bytes[..size]),
+                    &fpe::ff1::BinaryNumeralString::from_bytes_le(&bytes[..size], 10, 10),
                 )
             });
         });

--- a/benches/ff1.rs
+++ b/benches/ff1.rs
@@ -5,7 +5,7 @@ use criterion_cycles_per_byte::CyclesPerByte;
 fn ff1_binary_benchmark(c: &mut Criterion<CyclesPerByte>) {
     let bytes = vec![7; 1000];
 
-    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32], 2, 10).unwrap();
+    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32], 2).unwrap();
     let mut fpe_group = c.benchmark_group("fpe");
     for size in [10, 100, 1000].iter() {
         fpe_group.throughput(Throughput::Bytes(*size as u64));

--- a/benches/ff1.rs
+++ b/benches/ff1.rs
@@ -5,7 +5,7 @@ use criterion_cycles_per_byte::CyclesPerByte;
 fn ff1_binary_benchmark(c: &mut Criterion<CyclesPerByte>) {
     let bytes = vec![7; 1000];
 
-    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32], 2).unwrap();
+    let fpe_ff = fpe::ff1::FF1::<Aes256>::new(&[0; 32], 2, 10).unwrap();
     let mut fpe_group = c.benchmark_group("fpe");
     for size in [10, 100, 1000].iter() {
         fpe_group.throughput(Throughput::Bytes(*size as u64));

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -184,7 +184,20 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
     /// Creates a new FF1 object for the given key and radix.
     ///
     /// Returns an error if the given radix is not in [2..2^16].
-    pub fn new(key: &[u8], radix: u32, rounds: u8) -> Result<Self, ()> {
+    pub fn new(key: &[u8], radix: u32) -> Result<Self, ()> {
+        let ciph = CIPH::new(GenericArray::from_slice(key));
+        let radix = Radix::from(radix)?;
+        Ok(FF1 {
+            ciph,
+            radix,
+            rounds: 10,
+        })
+    }
+
+    /// Creates a new FF1 object for the given key and radix and number of rounds
+    ///
+    /// Returns an error if the given radix is not in [2..2^16].
+    pub fn with_rounds(key: &[u8], radix: u32, rounds: u8) -> Result<Self, ()> {
         let ciph = CIPH::new(GenericArray::from_slice(key));
         let radix = Radix::from(radix)?;
         Ok(FF1 {
@@ -402,7 +415,7 @@ mod tests {
             0x09, 0xCF, 0x4F, 0x3C,
         ];
 
-        let fpe_ff = FF1::<Aes256>::new(&key, 2, num_rounds).unwrap();
+        let fpe_ff = FF1::<Aes256>::with_rounds(&key, 2, num_rounds).unwrap();
 
         let encrypted = fpe_ff
             .encrypt(&[], &BinaryNumeralString::from_bytes_le(&bytes[..24]))
@@ -411,7 +424,7 @@ mod tests {
         assert_eq!(bytes[..24], decrypted.to_bytes_le());
 
         let num_rounds = 18;
-        let fpe_ff = FF1::<Aes256>::new(&key, 2, num_rounds).unwrap();
+        let fpe_ff = FF1::<Aes256>::with_rounds(&key, 2, num_rounds).unwrap();
 
         let encrypted = fpe_ff
             .encrypt(&[], &BinaryNumeralString::from_bytes_le(&bytes[..24]))

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -200,6 +200,20 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
         radix: u32,
         rounds: u8,
     ) -> Result<NS, ()> {
+        FF1::encrypt_with_cipher(&self.ciph, tweak, x, radix, rounds)
+    }
+
+    /// Encrypts the given numeral string.
+    ///
+    /// Returns an error if the numeral string is not in the required radix.
+    #[allow(clippy::many_single_char_names)]
+    pub fn encrypt_with_cipher<NS: NumeralString>(
+        ciph: &CIPH,
+        tweak: &[u8],
+        x: &NS,
+        radix: u32,
+        rounds: u8,
+    ) -> Result<NS, ()> {
         let radix = Radix::from(radix)?;
         let radix_u32 = radix.to_u32();
         if !x.is_valid(radix_u32) {
@@ -230,7 +244,7 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
 
         //  6i. Let Q = T || [0]^((-t-b-1) mod 16) || [i] || [NUM(B, radix)].
         // 6ii. Let R = PRF(P || Q).
-        let mut prf = Prf::new(&self.ciph);
+        let mut prf = Prf::new(&ciph);
         prf.update(&p);
         prf.update(tweak);
         for _ in 0..((((-(t as i32) - (b as i32) - 1) % 16) + 16) % 16) {
@@ -243,7 +257,7 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
             let r = prf.output();
 
             // 6iii. Let S be the first d bytes of R.
-            let s = generate_s(&self.ciph, r, d);
+            let s = generate_s(&ciph, r, d);
 
             // 6iv. Let y = NUM(S).
             let y = NS::Num::from_bytes(s);
@@ -279,6 +293,20 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
         radix: u32,
         rounds: u8,
     ) -> Result<NS, ()> {
+        FF1::decrypt_with_cipher(&self.ciph, tweak, x, radix, rounds)
+    }
+
+    /// Decrypts the given numeral string.
+    ///
+    /// Returns an error if the numeral string is not in the required radix.
+    #[allow(clippy::many_single_char_names)]
+    pub fn decrypt_with_cipher<NS: NumeralString>(
+        ciph: &CIPH,
+        tweak: &[u8],
+        x: &NS,
+        radix: u32,
+        rounds: u8,
+    ) -> Result<NS, ()> {
         let radix = Radix::from(radix)?;
         let radix_u32 = radix.to_u32();
         if !x.is_valid(radix_u32) {
@@ -309,7 +337,7 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
 
         //  6i. Let Q = T || [0]^((-t-b-1) mod 16) || [i] || [NUM(A, radix)].
         // 6ii. Let R = PRF(P || Q).
-        let mut prf = Prf::new(&self.ciph);
+        let mut prf = Prf::new(&ciph);
         prf.update(&p);
         prf.update(tweak);
         for _ in 0..((((-(t as i32) - (b as i32) - 1) % 16) + 16) % 16) {
@@ -323,7 +351,7 @@ impl<CIPH: NewBlockCipher + BlockEncrypt + BlockDecrypt + Clone> FF1<CIPH> {
             let r = prf.output();
 
             // 6iii. Let S be the first d bytes of R.
-            let s = generate_s(&self.ciph, r, d);
+            let s = generate_s(&ciph, r, d);
 
             // 6iv. Let y = NUM(S).
             let y = NS::Num::from_bytes(s);

--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -503,21 +503,21 @@ mod tests {
         for tv in test_vectors {
             let (ct, pt) = match tv.aes {
                 AesType::AES128 => {
-                    let ff = FF1::<Aes128>::new(&tv.key, tv.radix).unwrap();
+                    let ff = FF1::<Aes128>::new(&tv.key, tv.radix, 10).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),
                     )
                 }
                 AesType::AES192 => {
-                    let ff = FF1::<Aes192>::new(&tv.key, tv.radix).unwrap();
+                    let ff = FF1::<Aes192>::new(&tv.key, tv.radix, 10).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),
                     )
                 }
                 AesType::AES256 => {
-                    let ff = FF1::<Aes256>::new(&tv.key, tv.radix).unwrap();
+                    let ff = FF1::<Aes256>::new(&tv.key, tv.radix, 10).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),
@@ -596,7 +596,7 @@ mod tests {
 
         for tv in test_vectors {
             let (ct, pt, bct, bpt) = {
-                let ff = FF1::<Aes256>::new(&tv.key, tv.radix).unwrap();
+                let ff = FF1::<Aes256>::new(&tv.key, tv.radix, 10).unwrap();
                 (
                     ff.encrypt(&tv.tweak, &BinaryNumeralString(tv.pt.clone()))
                         .unwrap(),

--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -596,7 +596,7 @@ mod tests {
 
         for tv in test_vectors {
             let (ct, pt, bct, bpt) = {
-                let ff = FF1::<Aes256>::new(&tv.key, tv.radix, 10).unwrap();
+                let ff = FF1::<Aes256>::new(&tv.key, tv.radix).unwrap();
                 (
                     ff.encrypt(&tv.tweak, &BinaryNumeralString(tv.pt.clone()))
                         .unwrap(),

--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -503,21 +503,21 @@ mod tests {
         for tv in test_vectors {
             let (ct, pt) = match tv.aes {
                 AesType::AES128 => {
-                    let ff = FF1::<Aes128>::new(&tv.key, tv.radix, 10).unwrap();
+                    let ff = FF1::<Aes128>::new(&tv.key, tv.radix).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),
                     )
                 }
                 AesType::AES192 => {
-                    let ff = FF1::<Aes192>::new(&tv.key, tv.radix, 10).unwrap();
+                    let ff = FF1::<Aes192>::new(&tv.key, tv.radix).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),
                     )
                 }
                 AesType::AES256 => {
-                    let ff = FF1::<Aes256>::new(&tv.key, tv.radix, 10).unwrap();
+                    let ff = FF1::<Aes256>::new(&tv.key, tv.radix).unwrap();
                     (
                         ff.encrypt(&tv.tweak, &FlexibleNumeralString::from(tv.pt.clone())),
                         ff.decrypt(&tv.tweak, &FlexibleNumeralString::from(tv.ct.clone())),


### PR DESCRIPTION
Adding support to pass the number of feistel rounds as part of the FF1 object creation. 
See https://github.com/str4d/fpe/pull/22 for reference for similar requirement.