### PR TITLE
Move static_assert dependency to dev-dependencies section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["cryptography", "no-std"]
 cbc = { version = "0.1", default-features = false }
 cipher = "0.4"
 libm = "0.2"
-static_assertions = "1.1"
 
 num-bigint = { version = "0.4", optional = true, default-features = false }
 num-integer = { version = "0.1", optional = true, default-features = false }
@@ -24,6 +23,9 @@ num-traits = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 aes = "0.8"
+
+# Tests
+static_assertions = "1.1"
 
 # Benchmarks
 #aes-old = { package = "aes", version = "0.3" }


### PR DESCRIPTION
Types provided by the `static_assert` dependency are only ever used for tests, so it's best to declare that dependency in the `dev-dependencies` section, to reduce the dependency tree when doing a build for downstream crates.

More info about dev-dependencies: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies