### PR TITLE
Refresh CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.0
-          override: true
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --no-default-features
+        run: cargo build --verbose --no-default-features
 
   test:
     name: Test on ${{ matrix.os }}
@@ -34,31 +27,38 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.64.0
-          override: true
+      - uses: dtolnay/rust-toolchain@1.59.0
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose
+
+  bitrot:
+    name: Bitrot check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.59.0
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
+      # Build benchmarks to prevent bitrot
+      - name: Build benchmarks
+        run: cargo build --all --benches
 
   clippy-test:
-    name: Clippy (1.64.0)
+    name: Clippy (MSRV)
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.64.0
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@1.59.0
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
+      - run: rustup component add clippy
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.64.0)
+          name: Clippy (MSRV)
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 
@@ -69,11 +69,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@beta
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
+      - run: rustup component add clippy
       - name: Run Clippy (beta)
         uses: actions-rs/clippy-check@v1
         continue-on-error: true
@@ -85,41 +84,16 @@ jobs:
   doc-links:
     name: Intra-doc links
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.0
-          override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-
-      # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crates.
+      # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --document-private-items
+        run: cargo doc --document-private-items
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.0
-          override: true
-
-      # Ensure all code has been formatted with rustfmt
-      - run: rustup component add rustfmt
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ criterion = "0.4"
 criterion-cycles-per-byte = "0.4"
 
 [target.'cfg(unix)'.dev-dependencies]
+inferno = ">= 0.11, < 0.11.15"
 pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
 
 [features]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.56.0"
+components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,10 @@
 //! ```
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![deny(missing_docs)] // refuse to compile if documentation is missing
+// Refuse to compile if documentation is missing
+#![deny(missing_docs)]
+// Catch documentation errors caused by code changes.
+#![deny(rustdoc::broken_intra_doc_links)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
We enable testing on 1.59 by pinning `inferno`. It's fine to add upper bounds to dev-dependencies because they aren't part of the crate's public API.