### PR TITLE
`aes` 0.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Run tests
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       # Build benchmarks to prevent bitrot
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - run: rustup component add clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - wasm32-wasi
+          - wasm32-wasip1
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- MSRV is now 1.85.0.
+- Bumped dependencies to `cipher 0.5.1`, `cbc 0.2`.
+  - `aes 0.9` is now the minimum compatible crate version.
 
 ## [0.6.1] - 2023-04-13
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.85"
 description = "Format-preserving encryption"
 documentation = "https://docs.rs/fpe/"
 homepage = "https://github.com/str4d/fpe"
@@ -13,8 +13,8 @@ keywords = ["ff1"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cbc = { version = "0.1", default-features = false }
-cipher = "0.4"
+cbc = { version = "0.2", default-features = false }
+cipher = "0.5.1"
 libm = "0.2"
 
 num-bigint = { version = "0.4", optional = true, default-features = false }
@@ -22,7 +22,7 @@ num-integer = { version = "0.1", optional = true, default-features = false }
 num-traits = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
-aes = "0.8"
+aes = "0.9"
 
 # Tests
 proptest = "1.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ algorithms.
 The following algorithms are implemented:
 - FF1 (specified in [NIST Special Publication 800-38G](http://dx.doi.org/10.6028/NIST.SP.800-38G)).
 
-This crate requires Rust version 1.56 or greater.
+This crate requires Rust version 1.85 or greater.
 
 ## License
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.85.0"
 components = ["clippy", "rustfmt"]

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -64,7 +64,7 @@ impl Radix {
             let log_radix = 31 - radix.leading_zeros();
             Radix::PowerTwo {
                 radix,
-                min_len: cmp::max((MIN_RADIX_2_NS_LEN + log_radix - 1) / log_radix, MIN_NS_LEN),
+                min_len: cmp::max(MIN_RADIX_2_NS_LEN.div_ceil(log_radix), MIN_NS_LEN),
                 log_radix: u8::try_from(log_radix).unwrap(),
             }
         } else {

--- a/src/ff1.rs
+++ b/src/ff1.rs
@@ -4,8 +4,7 @@
 use core::cmp;
 
 use cipher::{
-    generic_array::GenericArray, Block, BlockCipher, BlockEncrypt, BlockEncryptMut, InnerIvInit,
-    KeyInit,
+    common::IvState, Array, Block, BlockCipherEncrypt, BlockModeEncrypt, InnerIvInit, KeyInit,
 };
 
 #[cfg(test)]
@@ -156,20 +155,29 @@ pub trait NumeralString: Sized {
     fn concat(a: Self::Ops, b: Self::Ops) -> Self;
 }
 
-#[derive(Clone)]
-struct Prf<CIPH: BlockCipher + BlockEncrypt> {
+struct Prf<CIPH: BlockCipherEncrypt> {
     state: cbc::Encryptor<CIPH>,
     // Contains the output when offset = 0, and partial input otherwise
     buf: [Block<CIPH>; 1],
     offset: usize,
 }
 
-impl<CIPH: BlockCipher + BlockEncrypt + Clone> Prf<CIPH> {
+impl<CIPH: BlockCipherEncrypt + Clone> Prf<CIPH> {
+    fn fork(&self, ciph: &CIPH) -> Self {
+        Self {
+            state: cbc::Encryptor::inner_iv_init(ciph.clone(), &self.state.iv_state()),
+            buf: self.buf.clone(),
+            offset: self.offset,
+        }
+    }
+}
+
+impl<CIPH: BlockCipherEncrypt + Clone> Prf<CIPH> {
     fn new(ciph: &CIPH) -> Self {
         let ciph = ciph.clone();
         Prf {
-            state: cbc::Encryptor::inner_iv_init(ciph, GenericArray::from_slice(&[0; 16])),
-            buf: [Block::<CIPH>::default()],
+            state: cbc::Encryptor::inner_iv_init(ciph, &Array::from_fn(|_| 0)),
+            buf: [Block::<CIPH>::from_fn(|_| 0)],
             offset: 0,
         }
     }
@@ -182,7 +190,7 @@ impl<CIPH: BlockCipher + BlockEncrypt + Clone> Prf<CIPH> {
             data = &data[to_read..];
 
             if self.offset == self.buf[0].len() {
-                self.state.encrypt_blocks_mut(&mut self.buf);
+                self.state.encrypt_blocks(&mut self.buf);
                 self.offset = 0;
             }
         }
@@ -197,7 +205,7 @@ impl<CIPH: BlockCipher + BlockEncrypt + Clone> Prf<CIPH> {
     }
 }
 
-fn generate_s<'a, CIPH: BlockEncrypt>(
+fn generate_s<'a, CIPH: BlockCipherEncrypt>(
     ciph: &'a CIPH,
     r: &'a Block<CIPH>,
     d: usize,
@@ -216,23 +224,25 @@ fn generate_s<'a, CIPH: BlockEncrypt>(
 }
 
 /// A struct for performing FF1 encryption and decryption operations.
-pub struct FF1<CIPH: BlockCipher> {
+pub struct FF1<CIPH> {
     ciph: CIPH,
     radix: Radix,
 }
 
-impl<CIPH: BlockCipher + KeyInit> FF1<CIPH> {
+impl<CIPH: KeyInit> FF1<CIPH> {
     /// Creates a new FF1 object for the given key and radix.
     ///
     /// Returns an error if the given radix is not in [2..2^16].
+    ///
+    /// Panics if the key size does not match that expected by the cipher.
     pub fn new(key: &[u8], radix: u32) -> Result<Self, InvalidRadix> {
-        let ciph = CIPH::new(GenericArray::from_slice(key));
+        let ciph = CIPH::new(key.try_into().expect("Invalid key length"));
         let radix = Radix::from_u32(radix)?;
         Ok(FF1 { ciph, radix })
     }
 }
 
-impl<CIPH: BlockCipher + BlockEncrypt + Clone> FF1<CIPH> {
+impl<CIPH: BlockCipherEncrypt + Clone> FF1<CIPH> {
     /// Encrypts the given numeral string.
     ///
     /// Returns an error if the numeral string is not in the required radix.
@@ -277,7 +287,7 @@ impl<CIPH: BlockCipher + BlockEncrypt + Clone> FF1<CIPH> {
             prf.update(&[0]);
         }
         for i in 0..10 {
-            let mut prf = prf.clone();
+            let mut prf = prf.fork(&self.ciph);
             prf.update(&[i]);
             prf.update(x_b.to_be_bytes(self.radix.to_u32(), b).as_ref());
             let r = prf.output();
@@ -348,7 +358,7 @@ impl<CIPH: BlockCipher + BlockEncrypt + Clone> FF1<CIPH> {
         }
         for i in 0..10 {
             let i = 9 - i;
-            let mut prf = prf.clone();
+            let mut prf = prf.fork(&self.ciph);
             prf.update(&[i]);
             prf.update(x_a.to_be_bytes(self.radix.to_u32(), b).as_ref());
             let r = prf.output();

--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -97,7 +97,7 @@ impl NumeralString for FlexibleNumeralString {
     type Ops = Self;
 
     fn is_valid(&self, radix: u32) -> bool {
-        self.0.iter().all(|n| (u32::from(*n) < radix))
+        self.0.iter().all(|n| u32::from(*n) < radix)
     }
 
     fn numeral_count(&self) -> usize {
@@ -297,7 +297,7 @@ impl NumeralString for BinaryNumeralString {
             // Simple case: no shifting necessary, just reversing and joining.
             b.data
                 .into_iter()
-                .chain(a.data.into_iter())
+                .chain(a.data)
                 .map(|b| b.reverse_bits())
                 .rev()
                 .collect()

--- a/src/ff1/alloc.rs
+++ b/src/ff1/alloc.rs
@@ -171,7 +171,7 @@ impl BinaryNumeralString {
         BinaryNumeralString(s.to_vec())
     }
 
-    /// Returns a Vec<u8>, with each byte written from the BinaryNumeralString
+    /// Returns a Vec, with each byte written from the BinaryNumeralString
     /// in little-endian bit order.
     pub fn to_bytes_le(&self) -> Vec<u8> {
         self.0.to_vec()

--- a/src/ff1/proptests.rs
+++ b/src/ff1/proptests.rs
@@ -56,7 +56,7 @@ proptest! {
         key in prop::array::uniform32(prop::num::u8::ANY),
         (radix, _, _) in valid_radix(),
     ) {
-        assert!(matches!(FF1::<Aes256>::new(&key, radix), Ok(_)));
+        assert!(FF1::<Aes256>::new(&key, radix).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
`aes` 0.9 was recently released, introducing breaking changes due to the [adoption of the `cipher` 0.5.1 traits](https://github.com/RustCrypto/block-ciphers/blob/master/aes/CHANGELOG.md#090-2026-04-10). Compared to the traits used in the `cipher` 0.4 version used by `fpe`, these new traits differ in both naming and method signatures, but offer equivalent functionality. But because this crate currently depends on the older `cipher` traits, and `aes` 0.9 implements only the new ones without any compatibility layer, `fpe` does not work with `aes` 0.9.

This PR updates `fpe` to use the newer `cipher` traits along with the related `cbc` traits, restoring compatibility with `aes` 0.9. This change requires a MSRV bump due to the updated `cipher` dependency, and it also drops compatibility with earlier `aes` versions. Users who need support for older `aes` releases can continue using a previous version of `fpe`.

I tried to do the update with the goal of preserving existing behavior as much as possible. In doing so, I followed the migration guidance outlined in the following PRs:

- https://github.com/RustCrypto/traits/pull/1482
- https://github.com/RustCrypto/block-modes/pull/91

Additionally, this PR addresses several lints identified by newer versions of Clippy and `cargo doc` and general CI staleness.